### PR TITLE
Implementation of assertEquals in JsonAsserterImpl

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -104,7 +104,7 @@ public class JsonAsserterImpl implements JsonAsserter {
 
     @Override
     public <T> JsonAsserter assertEquals(String path, T expected, String message) {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        return assertThat(path, equalTo(expected), message);
     }
 
     /**


### PR DESCRIPTION
Implementation of AssertEquals with message: assertEquals(String path,
T expected, String message).  Previously, this method was just
returning null.
